### PR TITLE
[WIP][SYCL][Driver] Initial support to enable --offload-arch option for SYCL.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -874,4 +874,12 @@ def warn_drv_openacc_without_cir
     : Warning<"OpenACC directives will result in no runtime behavior; use "
               "-fclangir to enable runtime effect">,
       InGroup<SourceUsesOpenACC>;
+def err_drv_sycl_offload_arch_missing_value :
+    Error<"must pass in a valid cpu or gpu architecture string to '--offload-arch'">;
+
+def err_drv_invalid_sycl_target : Error<"SYCL target is invalid: '%0'">;
+
+def warn_drv_sycl_offload_target_duplicate : Warning<
+  "SYCL offloading target '%0' is similar to target '%1' already specified; "
+  "will be ignored">, InGroup<SyclTarget>;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1751,3 +1751,8 @@ def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-stor
 
 // A warning for options that enable a feature that is not yet complete
 def ExperimentalOption : DiagGroup<"experimental-option">;
+
+// SYCL Warnings
+def SyclTarget : DiagGroup<"sycl-target">;
+
+

--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -109,6 +109,7 @@ enum class OffloadArch {
 
   CudaDefault = OffloadArch::SM_52,
   HIPDefault = OffloadArch::GFX906,
+  SYCLDefault = OffloadArch::BMG_G21_GPU,
 };
 
 static inline bool IsNVIDIAOffloadArch(OffloadArch A) {

--- a/clang/include/clang/Basic/OffloadArch.h
+++ b/clang/include/clang/Basic/OffloadArch.h
@@ -102,9 +102,9 @@ enum class OffloadArch {
   Generic, // A processor model named 'generic' if the target backend defines a
            // public one.
   // Intel CPUs
-  GRANITERAPIDS,
+  GRANITERAPIDS_CPU,
   // Intel GPUs
-  BMG_G21,
+  BMG_G21_GPU,
   LAST,
 
   CudaDefault = OffloadArch::SM_52,
@@ -121,11 +121,11 @@ static inline bool IsAMDOffloadArch(OffloadArch A) {
 }
 
 static inline bool IsIntelCPUOffloadArch(OffloadArch Arch) {
-  return Arch >= OffloadArch::GRANITERAPIDS && Arch < OffloadArch::BMG_G21;
+  return Arch >= OffloadArch::GRANITERAPIDS_CPU && Arch < OffloadArch::BMG_G21_GPU;
 }
 
 static inline bool IsIntelGPUOffloadArch(OffloadArch Arch) {
-  return Arch >= OffloadArch::BMG_G21 && Arch < OffloadArch::LAST;
+  return Arch >= OffloadArch::BMG_G21_GPU && Arch < OffloadArch::LAST;
 }
 
 static inline bool IsIntelOffloadArch(OffloadArch Arch) {

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -846,6 +846,22 @@ public:
   /// Compute the default -fmodule-cache-path.
   /// \return True if the system provides a default cache directory.
   static bool getDefaultModuleCachePath(SmallVectorImpl<char> &Result);
+  /// Vector of Macros that need to be added to the Host compilation in a
+  /// SYCL based offloading scenario.  These macros are gathered during
+  /// construction of the device compilations.
+  mutable std::vector<std::string> SYCLTargetMacro;
+
+  /// addSYCLTargetMacro - Add the given macro to the vector of args to be
+  /// added to the host compilation step.
+  void addSYCLTargetMacro(const llvm::opt::ArgList &Args,
+    StringRef Macro) const {
+    SYCLTargetMacro.push_back(Args.MakeArgString(Macro));
+  }
+
+  /// getSYCLTargetMacro - return the previously gathered macro target args.
+  llvm::ArrayRef<std::string> getSYCLTargetMacro() const {
+    return SYCLTargetMacro;
+  }
 };
 
 /// \return True if the last defined optimization level is -Ofast.

--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -88,9 +88,9 @@ static const OffloadArchToStringMap ArchNames[] = {
     GFX(1201), // gfx1201
     {OffloadArch::AMDGCNSPIRV, "amdgcnspirv", "compute_amdgcn"},
     // Intel CPUs
-    {OffloadArch::GRANITERAPIDS, "graniterapids", ""},
+    {OffloadArch::GRANITERAPIDS_CPU, "graniterapids", ""},
     // Intel GPUS
-    {OffloadArch::BMG_G21, "bmg_g21", ""},
+    {OffloadArch::BMG_G21_GPU, "bmg_g21", ""},
     {OffloadArch::Generic, "generic", ""},
     // clang-format on
 };

--- a/clang/lib/Basic/OffloadArch.cpp
+++ b/clang/lib/Basic/OffloadArch.cpp
@@ -88,9 +88,9 @@ static const OffloadArchToStringMap ArchNames[] = {
     GFX(1201), // gfx1201
     {OffloadArch::AMDGCNSPIRV, "amdgcnspirv", "compute_amdgcn"},
     // Intel CPUs
-    {OffloadArch::GRANITERAPIDS_CPU, "graniterapids", ""},
+    {OffloadArch::GRANITERAPIDS_CPU, "graniterapids_cpu", ""},
     // Intel GPUS
-    {OffloadArch::BMG_G21_GPU, "bmg_g21", ""},
+    {OffloadArch::BMG_G21_GPU, "bmg_g21_gpu", ""},
     {OffloadArch::Generic, "generic", ""},
     // clang-format on
 };

--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -240,8 +240,8 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
       case OffloadArch::GFX1201:
       case OffloadArch::AMDGCNSPIRV:
       case OffloadArch::Generic:
-      case OffloadArch::GRANITERAPIDS:
-      case OffloadArch::BMG_G21:
+      case OffloadArch::GRANITERAPIDS_CPU:
+      case OffloadArch::BMG_G21_GPU:
       case OffloadArch::LAST:
         break;
       case OffloadArch::UNKNOWN:

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2333,8 +2333,8 @@ void CGOpenMPRuntimeGPU::processRequiresDirective(const OMPRequiresDecl *D) {
       case OffloadArch::GFX1201:
       case OffloadArch::AMDGCNSPIRV:
       case OffloadArch::Generic:
-      case OffloadArch::GRANITERAPIDS:
-      case OffloadArch::BMG_G21:
+      case OffloadArch::GRANITERAPIDS_CPU:
+      case OffloadArch::BMG_G21_GPU:
       case OffloadArch::UNUSED:
       case OffloadArch::UNKNOWN:
         break;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -918,8 +918,7 @@ Driver::OpenMPRuntimeKind Driver::getOpenMPRuntime(const ArgList &Args) const {
 }
 
 static llvm::Triple getSYCLDeviceTriple(StringRef TargetArch) {
-  SmallVector<StringRef, 5> SYCLAlias = {"spir", "spir64", "spirv", "spirv32",
-                                         "spirv64"};
+  SmallVector<StringRef, 5> SYCLAlias = {"spirv", "spirv32", "spirv64"};
   if (llvm::is_contained(SYCLAlias, TargetArch)) {
     llvm::Triple TargetTriple;
     TargetTriple.setArchName(TargetArch);
@@ -932,6 +931,16 @@ static llvm::Triple getSYCLDeviceTriple(StringRef TargetArch) {
 
 static bool addSYCLDefaultTriple(Compilation &C,
                                  SmallVectorImpl<llvm::Triple> &SYCLTriples) {
+
+  llvm::Triple DefaultTriple = getSYCLDeviceTriple(
+      C.getDefaultToolChain().getTriple().isArch32Bit() ? "spirv32"
+                                                        : "spirv64");
+  for (const auto &SYCLTriple : SYCLTriples) {
+    if (SYCLTriple == DefaultTriple)
+      return false;
+    if(SYCLTriple.isSPIRV())
+      return false;
+  }
   // Check current set of triples to see if the default has already been set.
   for (const auto &SYCLTriple : SYCLTriples) {
     if (SYCLTriple.getSubArch() == llvm::Triple::NoSubArch &&

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1197,7 +1197,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             }
 
             for (const auto &TripleAndArchs : DerivedArchs)
-              SYCLTriples.insert(TripleAndArchs.first());
+              SYCLTriples.insert(TripleAndArchs.first()); //spirv64-intel-sycl
 
             for (StringRef Val : SYCLTriples) {
               llvm::Triple SYCLTargetTriple(getSYCLDeviceTriple(Val));

--- a/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
@@ -1,0 +1,28 @@
+/// Tests the behaviors of using -fsycl --offload-arch=<intel-cpu-values>.
+
+// SYCL AOT compilation to Intel CPUs using --offload-arch
+
+// RUN: %clangxx -### -fsycl --offload-arch=graniterapids_cpu %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=graniterapids_cpu
+
+// TARGET-TRIPLE-CPU: clang{{.*}} "-triple" "spirv64-unknown-unknown"
+// CLANG-OFFLOAD-PACKAGER-CPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl"
+
+// Tests for handling a missing architecture.
+//
+// RUN: not %clangxx  -fsycl --offload-arch= %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix=MISSING-OFFLOAD-ARCH-VALUE %s
+// RUN: not %clang_cl  -fsycl --offload-arch= %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix=MISSING-OFFLOAD-ARCH-VALUE %s
+
+// MISSING-OFFLOAD-ARCH-VALUE: error: must pass in a valid cpu or gpu architecture string to '--offload-arch'
+
+// Tests for handling a incorrect --offload-arch architecture vlue.
+//
+// RUN: not %clangxx  -fsycl --offload-arch=badArch %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix=BAD-ARCH %s
+// RUN: not %clang_cl  -fsycl --offload-arch=badArch %s -### 2>&1 \
+// RUN:   | FileCheck -check-prefix=BAD-ARCH %s
+
+// BAD-ARCH: error: SYCL target is invalid: 'badArch'
+

--- a/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-cpu.cpp
@@ -5,8 +5,8 @@
 // RUN: %clangxx -### -fsycl --offload-arch=graniterapids_cpu %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-CPU,CLANG-OFFLOAD-PACKAGER-CPU -DDEV_STR=graniterapids_cpu
 
-// TARGET-TRIPLE-CPU: clang{{.*}} "-triple" "spirv64-unknown-unknown"
-// CLANG-OFFLOAD-PACKAGER-CPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl"
+// TARGET-TRIPLE-CPU: clang{{.*}} "-triple" "spirv64-intel-sycl"
+// CLANG-OFFLOAD-PACKAGER-CPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-intel-sycl,arch=[[DEV_STR]],kind=sycl"
 
 // Tests for handling a missing architecture.
 //
@@ -25,4 +25,5 @@
 // RUN:   | FileCheck -check-prefix=BAD-ARCH %s
 
 // BAD-ARCH: error: SYCL target is invalid: 'badArch'
+
 

--- a/clang/test/Driver/sycl-offload-arch-intel-gpus.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-gpus.cpp
@@ -1,0 +1,11 @@
+/// Tests the behaviors of using -fsycl --offload-arch=<intel-gpu-values>.
+
+// SYCL AOT compilation to Intel GPUs using --offload-arch
+
+// RUN: %clangxx -### -fsycl --offload-arch=bmg_g21_gpu %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=bmg_g21_gpu -DMAC_STR=BMG_G21_GPU
+
+
+// TARGET-TRIPLE-GPU: clang{{.*}} "-triple" "spirv64-unknown-unknown"
+// CLANG-OFFLOAD-PACKAGER-GPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl"
+// CLANG-OFFLOAD-PACKAGER-GPU-OPTS: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl{{.*}}"

--- a/clang/test/Driver/sycl-offload-arch-intel-gpus.cpp
+++ b/clang/test/Driver/sycl-offload-arch-intel-gpus.cpp
@@ -6,6 +6,6 @@
 // RUN:   FileCheck %s --check-prefixes=TARGET-TRIPLE-GPU,CLANG-OFFLOAD-PACKAGER-GPU -DDEV_STR=bmg_g21_gpu -DMAC_STR=BMG_G21_GPU
 
 
-// TARGET-TRIPLE-GPU: clang{{.*}} "-triple" "spirv64-unknown-unknown"
-// CLANG-OFFLOAD-PACKAGER-GPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl"
-// CLANG-OFFLOAD-PACKAGER-GPU-OPTS: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-unknown-unknown,arch=[[DEV_STR]],kind=sycl{{.*}}"
+// TARGET-TRIPLE-GPU: clang{{.*}} "-triple" "spirv64-intel-sycl"
+// CLANG-OFFLOAD-PACKAGER-GPU: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-intel-sycl,arch=[[DEV_STR]],kind=sycl"
+// CLANG-OFFLOAD-PACKAGER-GPU-OPTS: clang-offload-packager{{.*}} "--image={{.*}}triple=spirv64-intel-sycl,arch=[[DEV_STR]],kind=sycl{{.*}}"

--- a/clang/unittests/Basic/OffloadArchTest.cpp
+++ b/clang/unittests/Basic/OffloadArchTest.cpp
@@ -21,14 +21,14 @@ TEST(OffloadArchTest, basic) {
   EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::GFX1201));
   EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::GFX12_GENERIC));
   EXPECT_TRUE(IsAMDOffloadArch(OffloadArch::AMDGCNSPIRV));
-  EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::GRANITERAPIDS));
+  EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::GRANITERAPIDS_CPU));
 
-  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::GRANITERAPIDS));
-  EXPECT_TRUE(IsIntelCPUOffloadArch(OffloadArch::GRANITERAPIDS));
-  EXPECT_FALSE(IsIntelGPUOffloadArch(OffloadArch::GRANITERAPIDS));
-  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::BMG_G21));
-  EXPECT_FALSE(IsIntelCPUOffloadArch(OffloadArch::BMG_G21));
-  EXPECT_TRUE(IsIntelGPUOffloadArch(OffloadArch::BMG_G21));
+  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::GRANITERAPIDS_CPU));
+  EXPECT_TRUE(IsIntelCPUOffloadArch(OffloadArch::GRANITERAPIDS_CPU));
+  EXPECT_FALSE(IsIntelGPUOffloadArch(OffloadArch::GRANITERAPIDS_CPU));
+  EXPECT_TRUE(IsIntelOffloadArch(OffloadArch::BMG_G21_GPU));
+  EXPECT_FALSE(IsIntelCPUOffloadArch(OffloadArch::BMG_G21_GPU));
+  EXPECT_TRUE(IsIntelGPUOffloadArch(OffloadArch::BMG_G21_GPU));
 
   EXPECT_FALSE(IsNVIDIAOffloadArch(OffloadArch::Generic));
   EXPECT_FALSE(IsAMDOffloadArch(OffloadArch::Generic));

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -221,6 +221,7 @@ public:
     NaCl, // Native Client
     AIX,
     CUDA,   // NVIDIA CUDA
+    SYCL,   // INTEL SYCL
     NVCL,   // NVIDIA OpenCL
     AMDHSA, // AMD HSA Runtime
     PS4,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -284,6 +284,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
   case AMDPAL: return "amdpal";
   case BridgeOS: return "bridgeos";
   case CUDA: return "cuda";
+  case SYCL: return "sycl";
   case Darwin: return "darwin";
   case DragonFly: return "dragonfly";
   case DriverKit: return "driverkit";
@@ -695,6 +696,7 @@ static Triple::OSType parseOS(StringRef OSName) {
     .StartsWith("nacl", Triple::NaCl)
     .StartsWith("aix", Triple::AIX)
     .StartsWith("cuda", Triple::CUDA)
+    .StartsWith("sycl", Triple::SYCL)
     .StartsWith("nvcl", Triple::NVCL)
     .StartsWith("amdhsa", Triple::AMDHSA)
     .StartsWith("ps4", Triple::PS4)


### PR DESCRIPTION
This patch is an attempt to have a single target triple string (`spirv64-intel-sycl`) to describe all the Intel devices (currently GPUs and CPUs) and the corresponding offloading device architecture is specified by the `--offload-arch` command-line argument, for the AOT compilation flow.

Example:
```
clang -fsycl --offload-arch=bmg_g21_gpu syclfile.cpp 
clang -fsycl --offload-arch=graniterapids_cpu syclfile.cpp
```

would imply `spirv64-intel-sycl` as target triple string for both the Intel CPU and GPU.

For JIT compilation, the default SYCL target triple string would be `spirv-unknown-unknown`

```
AOT flow : spirv32/64-intel-sycl
JIT flow:    spirv32/64-unknown-unknown
```


To Do:
Implement target macro additions to SYCL device compilation flow.
Fix default SYCL target triple string code for JIT compilation.